### PR TITLE
feat: shut down agents gracefully

### DIFF
--- a/scripts/keri/cf/demo-witness-oobis.json
+++ b/scripts/keri/cf/demo-witness-oobis.json
@@ -7,6 +7,9 @@
   "iurls": [
     "http://127.0.0.1:5642/oobi/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha/controller?name=Wan&tag=witness",
     "http://127.0.0.1:5643/oobi/BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapM/controller?name=Wes&tag=witness",
-    "http://127.0.0.1:5644/oobi/BIKKuvBwpmDVA4Ds-EpL5bt9OqPzWPja2LigFYZN2YfX/controller?name=Wil&tag=witness"
+    "http://127.0.0.1:5644/oobi/BIKKuvBwpmDVA4Ds-EpL5bt9OqPzWPja2LigFYZN2YfX/controller?name=Wil&tag=witness",
+    "http://127.0.0.1:5645/oobi/BM35JN8XeJSEfpxopjn5jr7tAHCE5749f0OobhMLCorE/controller?name=Wit&tag=witness",
+    "http://127.0.0.1:5646/oobi/BIj15u5V11bkbtAxMA7gcNJZcax-7TgaBMLsQnMHpYHP/controller?name=Wub&tag=witness",
+    "http://127.0.0.1:5647/oobi/BF2rZTW79z4IXocYRQnjjsOuvFUQv-ptCf8Yltd7PfsM/controller?name=Wyz&tag=witness"
   ]
 }

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,7 @@ setup(
     tests_require=[
         'coverage>=5.5',
         'pytest>=6.2.4',
+        'requests==2.32.3'
     ],
     setup_requires=[
     ],

--- a/src/keria/app/cli/commands/sig-fix.py
+++ b/src/keria/app/cli/commands/sig-fix.py
@@ -6,9 +6,8 @@ keri.kli.commands module
 """
 import argparse
 
-from hio import help
 from hio.base import doing
-from keri import kering
+from keri import help, kering
 from keri.app import habbing
 from keri.app.cli.common import existing
 from keri.core import serdering, coring

--- a/src/keria/app/cli/commands/start.py
+++ b/src/keria/app/cli/commands/start.py
@@ -1,16 +1,13 @@
 # -*- encoding: utf-8 -*-
 """
 KERIA
-keria.cli.keria.commands module
+keria.cli.keria.commands.start module
 
-Witness command line interface
+KERIA Agent server start command line interface (CLI) command
 """
 import argparse
-import logging
 import os
-import signal
 
-from hio.base import doing
 from keri import __version__
 from keri import help
 
@@ -78,59 +75,34 @@ parser.add_argument("--experimental-boot-username",
                     dest="bootUsername",
                     default=os.getenv("KERIA_EXPERIMENTAL_BOOT_USERNAME"))
 
+
 logger = help.ogler.getLogger()
+
+def launch(args):
+    agenting.runAgency(agenting.KERIAServerConfig(
+        name=args.name or "ahab",
+        base=args.base or "",
+        bran=args.bran,
+        adminPort=args.admin,
+        httpPort=args.http,
+        bootPort=args.boot,
+        configFile=args.configFile,
+        configDir=args.configDir,
+        keyPath=args.keypath,
+        certPath=args.certpath,
+        caFilePath=args.cafilepath,
+        logLevel=args.loglevel,
+        logFile=args.logfile,
+        cors=os.getenv("KERI_AGENT_CORS", "false").lower() in ("true", "1"),
+        releaseTimeout=int(os.getenv("KERIA_RELEASER_TIMEOUT", "86400")),
+        curls=getListVariable("KERIA_CURLS"),
+        iurls=getListVariable("KERIA_IURLS"),
+        durls=getListVariable("KERIA_DURLS"),
+        bootPassword=args.bootPassword,
+        bootUsername=args.bootUsername
+    ))
+    logger.info("Agent %s gracefully stopped", args.name)
 
 def getListVariable(name):
     value = os.getenv(name)
     return value.split(";") if value else None
-
-def launch(args):
-    help.ogler.level = logging.getLevelName(args.loglevel)
-    logger.setLevel(help.ogler.level)
-    if(args.logfile != None):
-        help.ogler.headDirPath = args.logfile
-        help.ogler.reopen(name=args.name, temp=False, clear=True)
-
-    logger.info("Starting Agent for %s listening: admin/%s, http/%s, boot/%s", args.name, args.admin, args.http, args.boot)
-    logger.info("PID: %s", os.getpid())
-
-    doers = agenting.setup(name=args.name or "ahab",
-                            base=args.base or "",
-                            bran=args.bran,
-                            adminPort=args.admin,
-                            httpPort=args.http,
-                            bootPort=args.boot,
-                            configFile=args.configFile,
-                            configDir=args.configDir,
-                            keypath=args.keypath,
-                            certpath=args.certpath,
-                            cafilepath=args.cafilepath,
-                            cors=os.getenv("KERI_AGENT_CORS", "false").lower() in ("true", "1"),
-                            releaseTimeout=int(os.getenv("KERIA_RELEASER_TIMEOUT", "86400")),
-                            curls=getListVariable("KERIA_CURLS"),
-                            iurls=getListVariable("KERIA_IURLS"),
-                            durls=getListVariable("KERIA_DURLS"),
-                            bootPassword=args.bootPassword,
-                            bootUsername=args.bootUsername)
-    agency = None
-    for doer in doers:
-        if isinstance(doer, agenting.Agency):
-            agency = doer
-            break
-
-    tock = 0.03125
-    doist = doing.Doist(limit=0.0, tock=tock, real=True)
-
-    def handle_sigterm(sig, frame):
-        agents = list(agency.agents.keys())
-        logger.info("Shutting down due to %s | stopping %s agents", signal.strsignal(sig), len(agents))
-        for caid in agents:
-            agency.shut(agency.agents[caid])
-        logger.info("Shutting down main Doist loop")
-        doist.exit()
-
-    signal.signal(signal.SIGTERM, handle_sigterm)
-
-    doist.do(doers=doers)
-
-    logger.info("Agent %s gracefully stopped", args.name)

--- a/src/keria/app/serving.py
+++ b/src/keria/app/serving.py
@@ -5,35 +5,67 @@ from keri import help
 
 logger = help.ogler.getLogger()
 
-class GracefulShutdownDoer(doing.DoDoer):
+class GracefulShutdownDoer(doing.Doer):
+    """
+    Shuts all Agency agents down before exiting the Doist loop, performing a graceful shutdown.
+    Sets up signal handlers in the Doer.enter lifecycle method and exits the Doist scheduler loop in Doer.exit
+    Checks for the signals in the Doer.recur lifecycle method.
+    """
     def __init__(self, doist, agency, **kwa):
+        """
+        Parameters:
+            doist (Doist): The Doist running this Doer
+            agency (Agency): The Agency containing Agent instances to be gracefully shut down
+            kwa (dict): Additional keyword arguments for Doer initialization
+        """
         self.doist: Doist = doist
         self.agency = agency
-        self.shutdown_flag = False
+        self.shutdown_received = False
 
-        # Register signal handler
-        signal.signal(signal.SIGTERM, self.handle_sigterm)
-        signal.signal(signal.SIGINT, self.handle_sigterm)
-        logger.info("Registered signal handlers for SIGTERM and SIGINT")
-
-        super().__init__(doers=[self.shutdown], **kwa)
+        super().__init__(**kwa)
 
     def handle_sigterm(self, signum, frame):
-        logger.info(f"Received signal {signum}, initiating graceful shutdown.")
-        self.shutdown_flag = True
+        """Handler function for SIGTERM"""
+        logger.info(f"Received SIGTERM, initiating graceful shutdown.")
+        self.shutdown_received = True
+
+    def handle_sigint(self, signum, frame):
+        """Handler function for SIGINT"""
+        logger.info(f"Received SIGINT, initiating graceful shutdown.")
+        self.shutdown_received = True
 
     def shutdown_agents(self, agents):
+        """Helper function to shut down the agents."""
         logger.info("Stopping %s agents", len(agents))
         for caid in agents:
             self.agency.shut(self.agency.agents[caid])
 
-    @doing.doize()
-    def shutdown(self, tymth, tock=0.0):
-        self.wind(tymth)
-        while not self.shutdown_flag:
-            yield tock
+    def enter(self):
+        """
+        Sets up signal handlers.
+        Lifecycle method called once when the Doist running this Doer enters the context for this Doer.
+        """
+        # Register signal handler
+        signal.signal(signal.SIGTERM, self.handle_sigterm)
+        signal.signal(signal.SIGINT, self.handle_sigint)
+        logger.info("Registered signal handlers for SIGTERM and SIGINT")
+
+    def recur(self, tock=0.0):
+        """Generator coroutine checking once per tock for shutdown flag"""
+        # Checks once per tock if the shutdown flag has been set and if so initiates the shutdown process
+        while not self.shutdown_received:
+            yield tock # will iterate forever in here until shutdown flag set
 
         # Once shutdown_flag is set, exit the Doist loop
         self.shutdown_agents(list(self.agency.agents.keys()))
+
+        return True # Returns a "done" status
+        # Causes the Doist scheduler to call .exit() lifecycle method below, killing the doist loop
+
+    def exit(self):
+        """
+        Exits the Doist loop.
+        Lifecycle method called once when the Doist running this Doer exits the context for this Doer.
+        """
         logger.info(f"Shutting down main Doist loop")
         self.doist.exit()

--- a/src/keria/app/serving.py
+++ b/src/keria/app/serving.py
@@ -1,0 +1,39 @@
+import signal
+
+from hio.base import doing, Doist
+from keri import help
+
+logger = help.ogler.getLogger()
+
+class GracefulShutdownDoer(doing.DoDoer):
+    def __init__(self, doist, agency, **kwa):
+        self.doist: Doist = doist
+        self.agency = agency
+        self.shutdown_flag = False
+
+        # Register signal handler
+        signal.signal(signal.SIGTERM, self.handle_sigterm)
+        signal.signal(signal.SIGINT, self.handle_sigterm)
+        logger.info("Registered signal handlers for SIGTERM and SIGINT")
+
+        super().__init__(doers=[self.shutdown], **kwa)
+
+    def handle_sigterm(self, signum, frame):
+        logger.info(f"Received signal {signum}, initiating graceful shutdown.")
+        self.shutdown_flag = True
+
+    def shutdown_agents(self, agents):
+        logger.info("Stopping %s agents", len(agents))
+        for caid in agents:
+            self.agency.shut(self.agency.agents[caid])
+
+    @doing.doize()
+    def shutdown(self, tymth, tock=0.0):
+        self.wind(tymth)
+        while not self.shutdown_flag:
+            yield tock
+
+        # Once shutdown_flag is set, exit the Doist loop
+        self.shutdown_agents(list(self.agency.agents.keys()))
+        logger.info(f"Shutting down main Doist loop")
+        self.doist.exit()

--- a/src/keria/app/serving.py
+++ b/src/keria/app/serving.py
@@ -8,8 +8,8 @@ logger = help.ogler.getLogger()
 class GracefulShutdownDoer(doing.Doer):
     """
     Shuts all Agency agents down before exiting the Doist loop, performing a graceful shutdown.
-    Sets up signal handlers in the Doer.enter lifecycle method and exits the Doist scheduler loop in Doer.exit
-    Checks for the signals in the Doer.recur lifecycle method.
+    Sets up signal handler in the Doer.enter lifecycle method and exits the Doist scheduler loop in Doer.exit
+    Checks for the shutdown flag being set in the Doer.recur lifecycle method.
     """
     def __init__(self, doist, agency, **kwa):
         """
@@ -29,11 +29,6 @@ class GracefulShutdownDoer(doing.Doer):
         logger.info(f"Received SIGTERM, initiating graceful shutdown.")
         self.shutdown_received = True
 
-    def handle_sigint(self, signum, frame):
-        """Handler function for SIGINT"""
-        logger.info(f"Received SIGINT, initiating graceful shutdown.")
-        self.shutdown_received = True
-
     def shutdown_agents(self, agents):
         """Helper function to shut down the agents."""
         logger.info("Stopping %s agents", len(agents))
@@ -47,8 +42,7 @@ class GracefulShutdownDoer(doing.Doer):
         """
         # Register signal handler
         signal.signal(signal.SIGTERM, self.handle_sigterm)
-        signal.signal(signal.SIGINT, self.handle_sigint)
-        logger.info("Registered signal handlers for SIGTERM and SIGINT")
+        logger.info("Registered signal handlers for SIGTERM")
 
     def recur(self, tock=0.0):
         """Generator coroutine checking once per tock for shutdown flag"""

--- a/tests/app/test_agenting.py
+++ b/tests/app/test_agenting.py
@@ -3,30 +3,32 @@
 KERIA
 keria.app.agenting module
 
-Testing the Mark II Agent
+Testing the Mark II Agent (KERIA)
 """
-from base64 import b64encode
 import json
+import multiprocessing
 import os
 import shutil
-
-import pytest
+import signal
+import time
+from base64 import b64encode
 
 import falcon
 import hio
+import pytest
+import requests
 from falcon import testing
 from hio.base import doing, tyming
 from hio.core import http, tcp
 from hio.help import decking
+from keri import core
 from keri import kering
 from keri.app import habbing, configing, indirecting, oobiing, querying
 from keri.app.agenting import Receiptor, WitnessReceiptor
-from keri import core
-from keri.core import coring, serdering
+from keri.core import serdering
 from keri.core.coring import MtrDex
 from keri.db import basing, dbing
 from keri.help import nowIso8601
-from keri.vc import proving
 from keri.vdr import credentialing
 
 from keria.app import agenting, aiding
@@ -35,13 +37,64 @@ from keria.testing.testing_helper import SCRIPTS_DIR
 
 
 def test_setup_no_http():
-    doers = agenting.setup(name="test", bran=None, adminPort=1234, bootPort=5678)
+    doers = agenting.setupDoers(agenting.KERIAServerConfig(
+        name="test",
+        adminPort=1234,
+        bootPort=5678,
+        httpPort=None,
+    ))
     assert len(doers) == 3
     assert isinstance(doers[0], agenting.Agency) is True
 
 def test_setup():
-    doers = agenting.setup("test", bran=None, adminPort=1234, bootPort=5678, httpPort=9999)
+    doers = agenting.setupDoers(agenting.KERIAServerConfig(
+        name="test",
+        adminPort=1234,
+        bootPort=5678,
+        httpPort=9999,
+    ))
     assert len(doers) == 4
+
+def wait_for_server(port, timeout=10):
+    """Poll server until it responds or until timeout"""
+    url=f"http://127.0.0.1:{port}/health"
+    start_time=time.time()
+    while time.time() - start_time < timeout:
+        try:
+            response = requests.get(url)
+            if response.status_code == 200:
+                return True # Server is up
+        except requests.ConnectionError:
+            pass # Server not ready yet
+        time.sleep(0.25) # Retry every 1/4 second
+    return False # Timeout
+
+def test_shutdown_signals():
+    config = agenting.KERIAServerConfig(
+        adminPort=3333,
+        bootPort=4444,
+        httpPort=5555,
+    )
+
+    # Test SIGTERM
+    agency_process = multiprocessing.Process(target=agenting.runAgency, args=[config])
+    agency_process.start()
+    assert wait_for_server(config.bootPort), "Agency did not start as expected."
+
+    os.kill(agency_process.pid, signal.SIGTERM)  # Send SigTerm to the process, signal 15
+    agency_process.join(timeout=10)
+    assert not agency_process.is_alive(), "SIGTERM: Agency process did not shut down as expected."
+    assert agency_process.exitcode == 0, f"SIGTERM: Agency exited with non-zero exit code {agency_process.exitcode}"
+
+    # Test SIGINT
+    agency_process = multiprocessing.Process(target=agenting.runAgency, args=[config])
+    agency_process.start()
+    assert wait_for_server(config.bootPort), "Agency did not start as expected."
+
+    os.kill(agency_process.pid, signal.SIGINT)  # Sends SigInt to the process, signal 2
+    agency_process.join(timeout=10)
+    assert not agency_process.is_alive(), "SIGINT: Agency process did not shut down as expected."
+    assert agency_process.exitcode == 0, f"SIGINT: Agency exited with non-zero exit code {agency_process.exitcode}"
 
 
 def test_load_ends(helpers):


### PR DESCRIPTION
This adds a few things, in order:
- the three remaining witness controller URLs to the demo-witness-oobis.json KERIA config file.
- Adds some LMDB error handling around the Agency.shut function used to shut down an agent.
- shuts down each agent gracefully prior to shutting down the main Doist.